### PR TITLE
Vulnerability fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,22 +70,22 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.6</version>
+      <version>2.11.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.5.8</version>
+      <version>4.5.13</version>
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
-      <version>3.10.0</version>
+      <version>3.14.9</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/fr/askjadev/xml/extfunctions/marklogic/result/EvalResultConverter.java
+++ b/src/main/java/fr/askjadev/xml/extfunctions/marklogic/result/EvalResultConverter.java
@@ -24,7 +24,6 @@
 package fr.askjadev.xml.extfunctions.marklogic.result;
 
 import com.marklogic.client.eval.EvalResult;
-import java.io.IOException;
 import java.math.BigDecimal;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -167,7 +166,7 @@ public class EvalResultConverter {
             }
             return null;
         }
-        catch (URISyntaxException | SaxonApiException | IOException ex) {
+        catch (URISyntaxException | SaxonApiException ex) {
             throw new XPathException("Error while trying to cast (one of) the query result(s): " + ex.getMessage());
         }
     }

--- a/src/test/java/fr/askjadev/xml/extfunctions/marklogic/MarkLogicQueryInvokeTest.java
+++ b/src/test/java/fr/askjadev/xml/extfunctions/marklogic/MarkLogicQueryInvokeTest.java
@@ -29,7 +29,6 @@ import com.marklogic.client.admin.ExtensionLibrariesManager;
 import com.marklogic.client.admin.ExtensionLibraryDescriptor;
 import com.marklogic.client.io.Format;
 import com.marklogic.client.io.InputStreamHandle;
-import java.io.IOException;
 import java.io.StringWriter;
 import java.net.URISyntaxException;
 import net.sf.saxon.Configuration;
@@ -391,11 +390,10 @@ public class MarkLogicQueryInvokeTest {
      * @throws XPathException
      * @throws TransformerConfigurationException
      * @throws URISyntaxException
-     * @throws IOException
      * @throws SaxonApiException
      */
     @Test
-    public void testXSL_ExternalVar_QueryOK() throws XPathException, TransformerConfigurationException, URISyntaxException, IOException, SaxonApiException {
+    public void testXSL_ExternalVar_QueryOK() throws XPathException, TransformerConfigurationException, URISyntaxException, SaxonApiException {
         TransformerFactory factory = TransformerFactory.newInstance();
         TransformerFactoryImpl tFactoryImpl = (TransformerFactoryImpl) factory;
         configuration.registerExtensionFunction(new MarkLogicQueryInvoke());
@@ -417,7 +415,7 @@ public class MarkLogicQueryInvokeTest {
             }
             it.close();
         }
-        catch (XPathException | TransformerConfigurationException | URISyntaxException | IOException | SaxonApiException ex) {
+        catch (XPathException | TransformerConfigurationException | URISyntaxException | SaxonApiException ex) {
             System.err.println(ex.getMessage());
             throw ex;
         }

--- a/src/test/java/fr/askjadev/xml/extfunctions/marklogic/MarkLogicQueryTest.java
+++ b/src/test/java/fr/askjadev/xml/extfunctions/marklogic/MarkLogicQueryTest.java
@@ -23,7 +23,6 @@
  */
 package fr.askjadev.xml.extfunctions.marklogic;
 
-import java.io.IOException;
 import java.io.StringWriter;
 import java.net.URISyntaxException;
 import javax.xml.transform.Source;
@@ -358,11 +357,10 @@ public class MarkLogicQueryTest {
      * @throws XPathException
      * @throws TransformerConfigurationException
      * @throws URISyntaxException
-     * @throws IOException
      * @throws SaxonApiException
      */
     @Test
-    public void testXSL_ExternalVar_QueryOK() throws XPathException, TransformerConfigurationException, URISyntaxException, IOException, SaxonApiException {
+    public void testXSL_ExternalVar_QueryOK() throws XPathException, TransformerConfigurationException, URISyntaxException, SaxonApiException {
         TransformerFactory factory = TransformerFactory.newInstance();
         TransformerFactoryImpl tFactoryImpl = (TransformerFactoryImpl) factory;
         configuration.registerExtensionFunction(new MarkLogicQuery());
@@ -384,7 +382,7 @@ public class MarkLogicQueryTest {
             }
             it.close();
         }
-        catch (XPathException | TransformerConfigurationException | URISyntaxException | IOException | SaxonApiException ex) {
+        catch (XPathException | TransformerConfigurationException | URISyntaxException | SaxonApiException ex) {
             System.err.println(ex.getMessage());
             throw ex;
         }

--- a/src/test/java/fr/askjadev/xml/extfunctions/marklogic/MarkLogicQueryURITest.java
+++ b/src/test/java/fr/askjadev/xml/extfunctions/marklogic/MarkLogicQueryURITest.java
@@ -23,7 +23,6 @@
  */
 package fr.askjadev.xml.extfunctions.marklogic;
 
-import java.io.IOException;
 import java.io.StringWriter;
 import java.net.URISyntaxException;
 import javax.xml.transform.Source;
@@ -414,11 +413,10 @@ public class MarkLogicQueryURITest {
      * @throws XPathException
      * @throws TransformerConfigurationException
      * @throws URISyntaxException
-     * @throws IOException
      * @throws SaxonApiException
      */
     @Test
-    public void testXSL_ExternalVar_QueryOK() throws XPathException, TransformerConfigurationException, URISyntaxException, IOException, SaxonApiException {
+    public void testXSL_ExternalVar_QueryOK() throws XPathException, TransformerConfigurationException, URISyntaxException, SaxonApiException {
         TransformerFactory factory = TransformerFactory.newInstance();
         TransformerFactoryImpl tFactoryImpl = (TransformerFactoryImpl) factory;
         configuration.registerExtensionFunction(new MarkLogicQueryURI());
@@ -440,7 +438,7 @@ public class MarkLogicQueryURITest {
             }
             it.close();
         }
-        catch (XPathException | TransformerConfigurationException | URISyntaxException | IOException | SaxonApiException ex) {
+        catch (XPathException | TransformerConfigurationException | URISyntaxException | SaxonApiException ex) {
             System.err.println(ex.getMessage());
             throw ex;
         }


### PR DESCRIPTION
Security : 3 Vulnerabilities from dependencies were found after the (in)famous log4shell alert. We update the libraries version numbers.

A change between commons-io 3.20.0 and 3.11.0 requires a modification of EvalResultConverter.java and three java test files.
Note : commons-io still has a minor number upgrade because "This maintains binary compatibility but not source compatibility"...